### PR TITLE
Saved sessions

### DIFF
--- a/RBReviewer/AppDelegate.m
+++ b/RBReviewer/AppDelegate.m
@@ -10,6 +10,8 @@
 #import "AFNetworkActivityIndicatorManager.h"
 #import "AFNetworkActivityLogger.h"
 
+static BOOL logActivity = NO;
+
 @interface AppDelegate ()
 
 @end
@@ -19,8 +21,10 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     [AFNetworkActivityIndicatorManager sharedManager].enabled = YES;
-    [[AFNetworkActivityLogger sharedLogger] startLogging];
-    [[AFNetworkActivityLogger sharedLogger] setLevel:AFLoggerLevelDebug];
+    if (logActivity) {
+        [[AFNetworkActivityLogger sharedLogger] startLogging];
+        [[AFNetworkActivityLogger sharedLogger] setLevel:AFLoggerLevelDebug];
+    }
     return YES;
 }
 

--- a/RBReviewer/Base.lproj/Main.storyboard
+++ b/RBReviewer/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="iyE-nb-rCv">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="PsM-Wm-SB6">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -211,7 +211,7 @@
         <!--Navigation Controller-->
         <scene sceneID="iiH-jd-4tq">
             <objects>
-                <navigationController storyboardIdentifier="LoginNavigationController" automaticallyAdjustsScrollViewInsets="NO" id="iyE-nb-rCv" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="loginNavigationController" automaticallyAdjustsScrollViewInsets="NO" id="iyE-nb-rCv" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="WyN-IJ-ioP">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>

--- a/RBReviewer/DSODoSomethingAPIClient.h
+++ b/RBReviewer/DSODoSomethingAPIClient.h
@@ -13,6 +13,7 @@
 
 @property (retain, nonatomic) NSDictionary *authHeaders;
 @property (retain, nonatomic) NSString *serviceName;
+@property (retain, nonatomic) NSString *serviceTokensName;
 @property (retain, nonatomic) NSDictionary *user;
 
 
@@ -20,7 +21,7 @@
 
 - (instancetype)initWithBaseURL:(NSURL *)url;
 
--(void)loginWithCompletionHandler:(void(^)(NSDictionary *))completionHandler andDictionary:(NSDictionary *)authValues andViewController:(UIViewController *)vc;
+-(void)loginWithCompletionHandler:(void(^)(NSDictionary *))completionHandler andUsername:(NSString *)username andPassword:(NSString *)password andViewController:(UIViewController *)vc;
 
 -(void)checkStatusWithCompletionHandler:(void(^)(NSDictionary *))completionHandler;
 
@@ -31,5 +32,7 @@
 - (void)logoutUserWithCompletionHandler:(void(^)(NSDictionary *))completionHandler;
 
 - (void)postReportbackReviewWithCompletionHandler:(void(^)(NSArray *))completionHandler :(NSDictionary *)values;
+
+- (NSDictionary *) getSavedLogin;
 
 @end

--- a/RBReviewer/DSODoSomethingAPIClient.h
+++ b/RBReviewer/DSODoSomethingAPIClient.h
@@ -34,5 +34,6 @@
 - (void)postReportbackReviewWithCompletionHandler:(void(^)(NSArray *))completionHandler :(NSDictionary *)values;
 
 - (NSDictionary *) getSavedLogin;
+- (NSMutableDictionary *) getSavedTokens;
 
 @end

--- a/RBReviewer/DSODoSomethingAPIClient.h
+++ b/RBReviewer/DSODoSomethingAPIClient.h
@@ -33,6 +33,7 @@
 
 - (void)postReportbackReviewWithCompletionHandler:(void(^)(NSArray *))completionHandler :(NSDictionary *)values;
 
+
 - (NSDictionary *) getSavedLogin;
 - (NSMutableDictionary *) getSavedTokens;
 

--- a/RBReviewer/DSODoSomethingAPIClient.h
+++ b/RBReviewer/DSODoSomethingAPIClient.h
@@ -23,7 +23,7 @@
 
 -(void)loginWithCompletionHandler:(void(^)(NSDictionary *))completionHandler andUsername:(NSString *)username andPassword:(NSString *)password andViewController:(UIViewController *)vc;
 
--(void)checkStatusWithCompletionHandler:(void(^)(NSDictionary *))completionHandler;
+-(void)checkStatusWithCompletionHandler:(void(^)(NSDictionary *))completionHandler andErrorHandler:(void(^)(NSDictionary *))errorHandler;
 
 - (void)getSingleInboxReportbackWithCompletionHandler:(void(^)(NSMutableArray *))completionHandler andTid:(NSInteger)tid;
 

--- a/RBReviewer/DSODoSomethingAPIClient.h
+++ b/RBReviewer/DSODoSomethingAPIClient.h
@@ -33,8 +33,10 @@
 
 - (void)postReportbackReviewWithCompletionHandler:(void(^)(NSArray *))completionHandler :(NSDictionary *)values;
 
-
 - (NSDictionary *) getSavedLogin;
+
 - (NSMutableDictionary *) getSavedTokens;
+
+- (BOOL) isLoggedIn;
 
 @end

--- a/RBReviewer/DSODoSomethingAPIClient.m
+++ b/RBReviewer/DSODoSomethingAPIClient.m
@@ -116,7 +116,8 @@
 {
     
     [self POST:@"auth/logout.json" parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
-        
+
+        [self deleteSavedTokens];
         completionHandler(responseObject);
         
     } failure:^(NSURLSessionDataTask *task, NSError *error) {
@@ -183,6 +184,7 @@
     }
     return authValues;
 }
+
 - (NSMutableDictionary *) getSavedTokens
 {
     NSMutableDictionary *savedTokens = [[NSMutableDictionary alloc] init];
@@ -195,6 +197,14 @@
         }
     }
     return savedTokens;
+}
+
+- (void) deleteSavedTokens
+{
+    NSMutableDictionary *tokens = [self getSavedTokens];
+    for(id key in tokens) {
+        [SSKeychain deletePasswordForService:self.serviceTokensName account:key];
+    }
 }
 
 @end

--- a/RBReviewer/DSODoSomethingAPIClient.m
+++ b/RBReviewer/DSODoSomethingAPIClient.m
@@ -93,9 +93,12 @@
     }];
 }
 
--(void)checkStatusWithCompletionHandler:(void(^)(NSDictionary *))completionHandler
+-(void)checkStatusWithCompletionHandler:(void(^)(NSDictionary *))completionHandler andErrorHandler:(void(^)(NSDictionary *))errorHandler
 {
-    
+    NSMutableDictionary *tokens = [self getSavedTokens];
+    if ([tokens count] > 0) {
+        [self addAuthHTTPHeaders];
+    }
     [self POST:@"system/connect.json" parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
 
         completionHandler(responseObject);
@@ -104,6 +107,7 @@
     } failure:^(NSURLSessionDataTask *task, NSError *error) {
         
         NSLog(@"Error: %@",error.localizedDescription);
+        errorHandler((NSDictionary *)error);
     }];
 }
 

--- a/RBReviewer/DSODoSomethingAPIClient.m
+++ b/RBReviewer/DSODoSomethingAPIClient.m
@@ -183,5 +183,18 @@
     }
     return authValues;
 }
+- (NSMutableDictionary *) getSavedTokens
+{
+    NSMutableDictionary *savedTokens = [[NSMutableDictionary alloc] init];
+    NSArray *tokens = [SSKeychain accountsForService:self.serviceTokensName];
+    if ([tokens count] > 0) {
+        for (NSDictionary *token in tokens) {
+            NSString *key = token[@"acct"];
+            NSString *value = [SSKeychain passwordForService:self.serviceTokensName account:key];
+            [savedTokens setObject:value forKey:key];
+        }
+    }
+    return savedTokens;
+}
 
 @end

--- a/RBReviewer/DSOFlagViewController.m
+++ b/RBReviewer/DSOFlagViewController.m
@@ -8,6 +8,7 @@
 
 #import "DSOFlagViewController.h"
 
+
 @interface DSOFlagViewController ()
 @property (strong, nonatomic) NSMutableArray *options;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
@@ -100,6 +101,7 @@
         }
     }
 }
+
 
 
 #pragma mark - Navigation

--- a/RBReviewer/DSOLoginViewController.m
+++ b/RBReviewer/DSOLoginViewController.m
@@ -37,37 +37,32 @@
 
 - (void) checkForKeychain
 {
-    NSArray *dsAccounts = [SSKeychain accountsForService:@"DoSomething.org"];
-    if ([dsAccounts count] > 0) {
-        NSDictionary *account = dsAccounts[0];
-        self.usernameTextField.text = account[@"acct"];
-        self.passwordTextField.text = [SSKeychain passwordForService:@"DoSomething.org" account:account[@"acct"]];
+    DSODoSomethingAPIClient *client = [DSODoSomethingAPIClient sharedClient];
+    
+    NSDictionary *authValues = [client getSavedLogin];
+    if ([authValues count] > 0) {
+        self.usernameTextField.text = authValues[@"username"];
+        self.passwordTextField.text = authValues[@"password"];
     }
 }
 
 
 - (IBAction)loginTapped:(id)sender {
 
-    NSDictionary *auth = [[NSDictionary alloc] init];
     NSString *username = self.usernameTextField.text;
     NSString *password = self.passwordTextField.text;
-
-    auth = @{@"username":username,
-              @"password":password};
     
     DSODoSomethingAPIClient *client = [DSODoSomethingAPIClient sharedClient];
 
     [client loginWithCompletionHandler:^(NSDictionary *response){
-        [SSKeychain setPassword:password forService:@"DoSomething.org" account:username];
-        NSLog(@"Response:%@", response);
-        NSDictionary *user = response[@"user"];
+
         UIViewController *vc = [self.storyboard instantiateViewControllerWithIdentifier:@"HomeNavigationController"];
         [self.navigationController presentViewController:vc animated:YES completion:NULL];
         [TSMessage showNotificationInViewController:vc
                                               title:@"Welcome back!"
-                                           subtitle:user[@"mail"]
+                                           subtitle:client.user[@"mail"]
                                         type:TSMessageNotificationTypeMessage];
         
-    } andDictionary:auth andViewController:self];
+    } andUsername:username andPassword:password andViewController:self];
 }
 @end


### PR DESCRIPTION
Fixes #2

Found a nasty bug that was causing Services logins to fail, seemingly randomly. The problem was fixed once I truncated the `sessions` table in the Drupal DB.  This PR saves session token and ID in the iOS Keychain, to avoid opening new sessions upon app crash / reload.